### PR TITLE
method for navigating to repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ carousel:
                 <p>Examples observed in Sri Lanka include elephants toppling trees on the electric fences to make them ineffective and digging up and destroying US Army surplus miniature seismic systems installed to detect crop-raiding elephants. Therefore, an adaptive approach is required that is based on multiple methods to detect elephants and that could randomly vary the actuation and this way prevent that the elephants get used to the system.</p>
 
                 <p>As an alternative strategy for electric fences and other fix detection systems we propose the use of an Adaptive Sensor Actuator System for Elephant Tracking (ASSET) for elephant detection and early warnings. The system will exploit the recent advances in flying robotic (quadcopter) and wireless sensor network (WSN) technology, which enables monitoring of the environment at low cost. The quadcopter chosen for this project is a Parrot Ar Drone 2.0 from Apple. It will be equipped identify the elephants.</p><br>
-            </div> 
+            </div>
             <div class="col-lg-4">
                 <h4>Recent News</h4>
                 <div class="hline"></div>
@@ -30,7 +30,11 @@ carousel:
                   </li>
                   {% endfor %}
                 </ul>
-            </div> 
+            </div>
+            <div class="col-lg-4">
+              <h4>GitHub Repositories</h4>
+              <p>Browse the <a href="https://github.com/scorelab/ASSET">ASSET</a> repository or explore <a href="https://github.com/scorelab">all repositories</a> from SCoRe Lab.</p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Added a new column like "Recent News" for repos.

I suggest to remove the "Repositories" link in the navigation bar to clear it up.
To not confuse users, the link should also be removed from the main SCoRe page.
What do you think?